### PR TITLE
Use the `newRelatedThroughInstance` method to prepare the through parents

### DIFF
--- a/src/HasRelationships.php
+++ b/src/HasRelationships.php
@@ -102,7 +102,9 @@ trait HasRelationships
             $segments = preg_split('/\s+as\s+/i', $class);
 
             $instance = Str::contains($segments[0], '\\')
-                ? $this->newRelatedThroughInstance($segments[0])
+                ? (method_exists($this, 'newRelatedThroughInstance')
+                    ? $this->newRelatedThroughInstance($segments[0])
+                    : new $segments[0]())
                 : (new Pivot())->setTable($segments[0]);
 
             if (isset($segments[1])) {

--- a/src/HasRelationships.php
+++ b/src/HasRelationships.php
@@ -102,7 +102,7 @@ trait HasRelationships
             $segments = preg_split('/\s+as\s+/i', $class);
 
             $instance = Str::contains($segments[0], '\\')
-                ? new $segments[0]()
+                ? $this->newRelatedThroughInstance($segments[0])
                 : (new Pivot())->setTable($segments[0]);
 
             if (isset($segments[1])) {


### PR DESCRIPTION
This PR uses the `newRelatedThroughInstance` method ([added on Laravel 9.5](https://github.com/laravel/framework/pull/41444)) to prepare the through parents.