### PR TITLE
Increase PHPStan level to 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "orchestra/testbench": "^9.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",
+        "phpstan/phpstan-phpunit": "^1.4",
         "phpunit/phpunit": "^11.0",
         "staudenmeir/eloquent-json-relations": "^1.11",
         "staudenmeir/laravel-adjacency-list": "^1.21"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,8 @@
 includes:
     - ./vendor/larastan/larastan/extension.neon
     - ./vendor/phpstan/phpstan-mockery/extension.neon
+    - ./vendor/phpstan/phpstan-phpunit/extension.neon
+    - ./vendor/phpstan/phpstan-phpunit/rules.neon
 parameters:
     level: 5
     paths:
@@ -9,3 +11,4 @@ parameters:
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         - '#Unsafe usage of new static\(\).#'
+        - '#Parameter \#\d+ \$relations of method Illuminate\\Database\\Eloquent\\Collection<[^>]+\>::load\(\) expects#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
     - ./vendor/larastan/larastan/extension.neon
     - ./vendor/phpstan/phpstan-mockery/extension.neon
 parameters:
-    level: 4
+    level: 5
     paths:
         - src
         - tests

--- a/tests/Concatenation/LaravelAdjacencyList/AncestorsTest.php
+++ b/tests/Concatenation/LaravelAdjacencyList/AncestorsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Concatenation\LaravelAdjacencyList;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Tests\Concatenation\LaravelAdjacencyList\Models\User;
 
@@ -65,7 +66,7 @@ class AncestorsTest extends TestCase
     public function testLazyEagerLoading()
     {
         $users = User::all()->load([
-            'ancestorPosts' => fn (HasManyDeep $query) => $query->orderBy('id'),
+            'ancestorPosts' => fn (Relation $query) => $query->getQuery()->orderBy('id'),
         ]);
 
         $this->assertEquals([], $users[0]->ancestorPosts->pluck('id')->all());

--- a/tests/Concatenation/LaravelAdjacencyList/BloodlineTest.php
+++ b/tests/Concatenation/LaravelAdjacencyList/BloodlineTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Concatenation\LaravelAdjacencyList;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Tests\Concatenation\LaravelAdjacencyList\Models\User;
 
@@ -35,7 +36,7 @@ class BloodlineTest extends TestCase
     public function testLazyEagerLoading()
     {
         $users = User::all()->load([
-            'bloodlinePosts' => fn (HasManyDeep $query) => $query->orderBy('id'),
+            'bloodlinePosts' => fn (Relation $query) => $query->getQuery()->orderBy('id'),
         ]);
 
         $this->assertEquals([10, 20, 30, 40, 50, 60, 70, 80], $users[0]->bloodlinePosts->pluck('id')->all());


### PR DESCRIPTION
There is only one type of PHPStan error:

> Parameter #1 $relations of method Illuminate\Database\Eloquent\Collection<int,Tests\Concatenation\LaravelAdjacencyList\Models\User>::load() expects array<(callable(Illuminate\Database\Eloquent\Builder<Tests\Concatenation\LaravelAdjacencyList\Models\User>): mixed)|string>|string, array{ancestorPosts: Closure(Staudenmeir\EloquentHasManyDeep\HasManyDeep): Staudenmeir\EloquentHasManyDeep\HasManyDeep<Illuminate\Database\Eloquent\Model>} given.

The affected code looks like this:

```php
$users = User::all()->load([
    'ancestorPosts' => fn (HasManyDeep $query) => $query->orderBy('id'),
]);
```

The first issue is that the parameter type of `Collection::load()` is incorrect. The callable function actually gets passed a relationship, not an Eloquent builder:

```php
* @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Relations\Relation): mixed)|string>|string  $relations
```

However, this fix doesn't resolve the error:

> Parameter #1 $relations of method Illuminate\Database\Eloquent\Collection<int,Tests\Concatenation\LaravelAdjacencyList\Models\User>::load() expects array<(callable(Illuminate\Database\Eloquent\Relations\Relation):  
         mixed)|string>|string, array{ancestorPosts: Closure(Staudenmeir\EloquentHasManyDeep\HasManyDeep): Staudenmeir\EloquentHasManyDeep\HasManyDeep<Illuminate\Database\Eloquent\Model>} given.

The error only goes away when you change the parameter's type to `Relation` (despite `HasManyDeep` being a subclass of `Relation`):

```php
$users = User::all()->load([
    'ancestorPosts' => fn (Relation $query) => $query->orderBy('id'),
]);
```

With this change, however, PHPStan can't handle methods calls anymore despite the `Relation` class's [Eloquent builder mixin](https://github.com/laravel/framework/blob/4529498671704a2ea4bae4af1e3f8ee48ca8dfd0/src/Illuminate/Database/Eloquent/Relations/Relation.php#L21):

> Call to an undefined method Illuminate\Database\Eloquent\Relations\Relation::orderBy(). 

@calebdw As discussed.

@SanderMuller Maybe you have an idea?