### PR TITLE
Use alias for deferred provider

### DIFF
--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -12,6 +12,12 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
     public function boot(): void
     {
         $this->publishConfig();
+
+        // Laravel only allows a single deferred service provider to claim
+        // responsibility for a given class, interface, or service in the
+        // provides() method. To ensure this provider is properly loaded
+        // when running the ModelsCommand we bind an alias and use that instead.
+        $this->app->alias(ModelsCommand::class, DeepRelationsHook::class);
     }
 
     public function register(): void
@@ -22,12 +28,12 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
     }
 
     /**
-     * @return list<class-string<\Illuminate\Console\Command>>
+     * @return list<class-string<\Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface>>
      */
     public function provides(): array
     {
         return [
-            ModelsCommand::class,
+            DeepRelationsHook::class,
         ];
     }
 


### PR DESCRIPTION
This PR changes the way the deferred service provider is loaded after the ide-helper `ModelsCommand` is requested from the container.

I only found out about this issue when using multiple packages using the `ModelsCommand` within the `providers` method of the deferred service provider. Where only one of the hooks was actually registered properly when running the models command.

Apparently Laravel only allows a single deferred service provider to claim responsibility for a given class, interface, or service in the provides() method.

You can confirm this by checking the `bootstrap/cache/services.php` after a composer dump-autoload:
```php
'deferred' =>
array (
    'Barryvdh\\LaravelIdeHelper\\Console\\ModelsCommand' => 'Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider',
)
```

After installing this package you can see it hijacked the binding:
```php
'deferred' =>
array (
    'Barryvdh\\LaravelIdeHelper\\Console\\ModelsCommand' => 'Staudenmeir\\EloquentHasManyDeep\\IdeHelperServiceProvider',
)
```

To easiest solution is to use an alias for the ModelsCommand to prevent hijacking the binding. Resulting in a non-invasive binding.

```php
'deferred' =>
array (
    'Barryvdh\\LaravelIdeHelper\\Console\\ModelsCommand' => 'Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider',
    'Staudenmeir\\EloquentHasManyDeep\\IdeHelper\\DeepRelationsHook' => 'Staudenmeir\\EloquentHasManyDeep\\IdeHelperServiceProvider',
)
```
